### PR TITLE
Update redirect

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,4 +1,4 @@
 {{- $latest   := .Site.Params.versions.latest }}
 /docs/latest     /docs
 /docs/latest/*   /docs/:splat
-/docs/security   /security
+/security   /docs/security


### PR DESCRIPTION
Our security page lives at `/docs/security` now. We want `/security` to map to `/docs/security`. Currently the redirect is doing the opposite of this.