### PR TITLE
Add chat redirect

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -3,3 +3,4 @@
 /docs/latest     /docs/concepts/overview
 /docs/latest/*   /docs/:splat
 /security   /docs/security
+/chat   https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LTgzZDQ3NzZlNDkzMGIyYjU1MTA0NzIwMjFjODFiZjA0YjFmYmQyOTZiNzNkNzg1N2U1MDdlZTIxNTU5NWNhNjk

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -83,7 +83,7 @@
             <a class="navbar-item" href="https://forum.tikv.org" target="_blank">
               Forum
             </a>
-            <a class="navbar-item" href="https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LTgzZDQ3NzZlNDkzMGIyYjU1MTA0NzIwMjFjODFiZjA0YjFmYmQyOTZiNzNkNzg1N2U1MDdlZTIxNTU5NWNhNjk" target="_blank">
+            <a class="navbar-item" href="/chat" target="_blank">
               Chat
             </a>
             <a class="navbar-item" href="/adopters">


### PR DESCRIPTION
Adds a convenient chat redirect at `tikv.org/chat` so we don't need this complicated Slack link.