### PR TITLE
Build future posts on publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@ serve:
 serve-production:
 	hugo server \
 		--disableFastRender \
+		--buildFuture \
 		--bind 0.0.0.0
 
 production-build:
-	hugo --minify
+	hugo --minify \
+		--buildFuture
 
 preview-build:
 	hugo \


### PR DESCRIPTION
Currently if we merge a PR with some future date it won't build until that date. This changes that so it builds all future dates as well.