### PR TITLE
reference/pd-ctl: update region miss-peer check usage

### DIFF
--- a/content/docs/3.0/reference/tools/pd-ctl.md
+++ b/content/docs/3.0/reference/tools/pd-ctl.md
@@ -21,7 +21,7 @@ As a command line tool of PD, PD Control obtains the state information of the cl
 Single-command mode:
 
 ```bash
-./pd-ctl store -d -u http://127.0.0.1:2379
+./pd-ctl store -u http://127.0.0.1:2379
 ```
 
 Interactive mode:
@@ -54,7 +54,7 @@ Use TLS to encrypt:
 ### \-\-detach,-d
 
 + Use single command line mode (not entering readline)
-+ Default: false
++ Default: true
 
 ### --cacert
 

--- a/content/docs/3.0/reference/tools/pd-ctl.md
+++ b/content/docs/3.0/reference/tools/pd-ctl.md
@@ -711,7 +711,7 @@ Description of various types:
 Usage:
 
 ```bash
->> region miss-peer
+>> region check miss-peer
 {
   "count": 2,
   "regions": [...]


### PR DESCRIPTION
This PR updated the usage for  `check miss-peer` in PD ctl tool

Related PRs: 
https://github.com/pingcap/docs-cn/pull/1824
https://github.com/pingcap/docs/pull/1508