### PR TITLE
Refresh chat links

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -3,4 +3,4 @@
 /docs/latest     /docs/{{ $latest }}/concepts/ 301
 /docs/latest/*   /docs/{{ $latest }}/:splat 301
 /security   /docs/{{ $latest }}/tasks/secure/ 301
-/chat   https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LTgzZDQ3NzZlNDkzMGIyYjU1MTA0NzIwMjFjODFiZjA0YjFmYmQyOTZiNzNkNzg1N2U1MDdlZTIxNTU5NWNhNjk
+/chat   https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LWVlMWMzMDkyNWE5ZjY1ODAzMWUwZGVhNGNhYTc3MzJhYWE0Y2FjYjliYzY1OWJlYTc4OWVjZWM1NDkwN2QxNDE


### PR DESCRIPTION
Slack has a per-link limit on number of clicks so we need to refresh this periodically.

I sigh in disappointment that this PR needs to exist.

Trivial PR so just merge with 1 review. :)