### PR TITLE
Update Percolator paper URL

### DIFF
--- a/content/deep-dive/distributed-transaction/percolator.md
+++ b/content/deep-dive/distributed-transaction/percolator.md
@@ -6,7 +6,7 @@ menu:
         weight: 5
 ---
 
-TiKV supports distributed transactions, which is inspired by Google's [Percolator](https://ai.google/research/pubs/pub36726.pdf). In this section, we will briefly introduce Percolator and how we make use of it in TiKV.
+TiKV supports distributed transactions, which is inspired by Google's [Percolator](https://research.google/pubs/pub36726.pdf). In this section, we will briefly introduce Percolator and how we make use of it in TiKV.
 
 ## What is Percolator?
 


### PR DESCRIPTION
The old url is expired.