### PR TITLE
Remove 'a' to fix a grammar mistake

### DIFF
--- a/content/deep-dive/consensus-algorithm/introduction.md
+++ b/content/deep-dive/consensus-algorithm/introduction.md
@@ -10,7 +10,6 @@ When building a distributed system one principal goal is often to build in fault
 
 Distributed consensus algorithms often take the form of a replicated state machine and log. Each state machine accepts inputs from its log, and represents the value(s) to be replicated, for example, a change to a hash table. They allow a collection of machines to work as a coherent group that can survive the failures of some of its members.
 
-Two well known distributed consensus algorithms are [Paxos](https://lamport.azurewebsites.net/pubs/paxos-simple.pdf) and [Raft](https://raft.github.io/raft.pdf). Paxos is used in systems like [Chubby](http://research.google.com/archive/chubby.html) by Google, and Raft is used in systems like [TiKV](https://github.com/tikv/tikv) or [etcd](https://github.com/coreos/etcd/tree/master/raft). Raft is generally seen as a more understandable and simpler to implement than Paxos.
+Two well known distributed consensus algorithms are [Paxos](https://lamport.azurewebsites.net/pubs/paxos-simple.pdf) and [Raft](https://raft.github.io/raft.pdf). Paxos is used in systems like [Chubby](http://research.google.com/archive/chubby.html) by Google, and Raft is used in systems like [TiKV](https://github.com/tikv/tikv) or [etcd](https://github.com/coreos/etcd/tree/master/raft). Raft is generally seen as more understandable and simpler to implement than Paxos.
 
 In TiKV we harness Raft for distributed consensus. We found it much easier to understand both the algorithm, and how it will behave in even truly perverse scenarios.
-


### PR DESCRIPTION
Signed-off-by: Youwithouto <youwithouto.z@gmail.com>

<!--Thanks for your contribution to TiKV documentation. -->

### What is changed?

Remove 'a' from the sentence "Raft is generally seen as a more understandable and simpler to implement than Paxos." in the [Consensus algorithm section](https://tikv.org/deep-dive/consensus-algorithm/introduction/) of the doc website.

### Any related PRs or issues?

<!--Provide a reference link that is related to your change. -->

### Which version does your change affect?
