### PR TITLE
Change the upstream URL to the correct one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ If you have a specific idea of a fix or update, and [you have everything ready](
 
     ```bash
     $ cd website
-    $ git remote add upstream git@github.com:tikv/tikv.git
+    $ git remote add upstream git@github.com:tikv/website.git
     $ git remote -v
     origin	git@github.com:$GITHUB_USER/website.git (fetch)
     origin	git@github.com:$GITHUB_USER/website.git (push)


### PR DESCRIPTION
Signed-off-by: Youwithouto <youwithouto.z@gmail.com>

<!--Thanks for your contribution to TiKV documentation. -->

### What is changed?

The `upstream URL` in the `CONTRIBUTING.md` file is incorrect. 

This fix changes the `upstream URL` from `git@github.com:tikv/tikv.git` to `git@github.com:tikv/website.git`.

### Any related PRs or issues?

<!--Provide a reference link that is related to your change. -->

### Which version does your change affect?
