### PR TITLE
fix wrong name.

### DIFF
--- a/content/deep-dive/distributed-transaction/optimized-percolator.md
+++ b/content/deep-dive/distributed-transaction/optimized-percolator.md
@@ -50,8 +50,8 @@ For example:
 Txn2 reads `"k1"` twice but gets two different results. If `commit_ts` is
 allocated from PD, this will not happen, because Txn2's first read must happen
 before Txn1's prewrite while Txn1's `commit_ts` must be requested after
-finishing prewrite. And as a result, Txn2's `commit_ts` must be larger than
-Txn1's `start_ts`.
+finishing prewrite. And as a result, Txn1's `commit_ts` must be larger than
+Txn2's `start_ts`.
 
 On the other hand, `commit_ts` can't be arbitrarily large. If the `commit_ts` is
 ahead of the actual time, the committed data may be unreadable by other new


### PR DESCRIPTION
It means that Txn1's request `commit_ts` after Txn2's requested `start_ts`,so Txn1's  `commit_ts` > Txn2's  `start_ts`.
