### PR TITLE
Adds RSS feed for the blog

### DIFF
--- a/layouts/partials/blog/hero.html
+++ b/layouts/partials/blog/hero.html
@@ -7,6 +7,11 @@
       <h1 class="title is-size-1 is-size-2-mobile has-text-white has-text-weight-light{{ if $author }} is-spaced{{ end }}">
         {{ .Title }}
       </h1>
+
+      {{ if eq .RelPermalink "/blog/" }}
+      <a href="/blog/index.xml"><i class="fa fa-rss"></i> &nbsp; Subscribe via RSS</a>
+      {{ end }}
+
       {{ with $author }}
       <p class="subtitle is-size-3 is-size-4-mobile has-text-white-bis has-text-weight-light">
         {{ . | markdownify }}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,6 +1,8 @@
 {{ $favicon := site.Params.favicon | relURL }}
+{{ $rssFeed := "blog/index.xml" | absURL }}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {{ hugo.Generator }}
 
 <link rel="shorcut icon" href="{{ $favicon }}">
+<link rel="alternate" type="application/rss+xml" href="{{ $rssFeed }}" title="TiKV"/>


### PR DESCRIPTION
<!--Thanks for your contribution to TiKV documentation. -->

### What is changed?

Added "Subscribe via RSS" link right after the blog title. screenshots :point_down: 

Also added a `<link>` tag in `<head>` that points to the RSS feed URL. This helps RSS readers in picking up the RSS feed URL just by typing the base URL (E.g. https://tikv.org). Without this tag, the user may need to type the full URL (https://tikv.org/blog/index.xml) in the RSS feed reader application.

#### Before
![image](https://user-images.githubusercontent.com/4211715/83969255-94c66680-a8ec-11ea-8b9b-70c85a9545b9.png)

#### After
![image](https://user-images.githubusercontent.com/4211715/83969242-7b251f00-a8ec-11ea-9cbf-44c0b798c65f.png)

### Any related PRs or issues?

#167 

### Which version does your change affect?
N/A