### PR TITLE
Add a community page and a page for each SIG

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ disableKinds: ["taxonomy", "taxonomyTerm"]
 menu:
     nav:
     - name: Community
-      url: /contribute
+      url: /community/community/
     - name: Contribute
       parent: Community
       weight: 1

--- a/content/community/community.md
+++ b/content/community/community.md
@@ -1,0 +1,13 @@
+---
+title: Community
+description: The TiKV community
+---
+
+TiKV is an open source project with an active community. TiKV's source code is hosted on [GitHub](https://github.com/tikv/tikv) and is a [Cloud Native Computing Foundation](https://www.cncf.io) incubating project. We have information about how to [contribute here](/docs/3.0/reference/contribute/).
+
+The TiKV community is organised into special interest groups (SIGs). More information about the community and its governance is in the [community repository](https://github.com/tikv/community). The current roster of SIGs is below, follow the links for more information.
+
+* [Coprocessor](/community/sig-coprocessor/)
+* [Engine](/community/sig-engine/)
+* [Raft](/community/sig-raft/)
+* [Transaction](/community/sig-transaction/)

--- a/content/community/sig-coprocessor.md
+++ b/content/community/sig-coprocessor.md
@@ -1,0 +1,10 @@
+---
+title: Coprocessor SIG
+description: Information about the coprocessor special interest group
+---
+
+Coprocessor SIG focuses on the Coprocessor module of the TiKV project, which is the module in TiKV that handles TiDB's pushdown calculations. The primary responsibility of this SIG is to discuss, plan, develop, and maintain the future development of the Coprocessor module.
+
+For more information, see [our page](https://github.com/tikv/community/tree/master/sig/coprocessor) in the TiKV community repo.
+
+You can contact the coprocessor SIG via [Slack](https://slack.tidb.io/invite?team=tikv-wg&channel=sig-copr&ref=github_sig).

--- a/content/community/sig-engine.md
+++ b/content/community/sig-engine.md
@@ -1,0 +1,10 @@
+---
+title: Engine SIG
+description: Information about the engine special interest group
+---
+
+Covers engine related work in TiKV, including supporting various engines in TiKV and engine improvements.
+
+For more information, see [our page](https://github.com/tikv/community/tree/master/sig/engine) in the TiKV community repo.
+
+You can contact the coprocessor SIG via [Slack](https://slack.tidb.io/invite?team=tikv-wg&channel=sig-engine&ref=github-sig).

--- a/content/community/sig-raft.md
+++ b/content/community/sig-raft.md
@@ -1,0 +1,10 @@
+---
+title: Raft SIG
+description: Information about the Raft special interest group
+---
+
+Covers [Raf related work in TiKV, including optimize [raft-rs](https://github.com/tikv/raft-rs) and the Multi-Raft implementation in TiKV.
+
+For more information, see [our page](https://github.com/tikv/community/tree/master/sig/raft) in the TiKV community repo.
+
+You can contact the coprocessor SIG via [Slack](https://slack.tidb.io/invite?team=tikv-wg&channel=sig-raft&ref=github-sig).

--- a/content/community/sig-transaction.md
+++ b/content/community/sig-transaction.md
@@ -1,0 +1,24 @@
+---
+title: Transaction SIG
+description: Information about the transaction special interest group
+---
+
+The transactions special interest group (SIG-transaction) are a group of people interested in transactions in distributed databases. We have a focus on transactions in TiKV and TiDB, but discuss academic work and other implementations too.
+
+The SIG is in the process of starting up. In the near future we hope to host:
+
+* talks on distributed transactions,
+* a reading group for academic papers,
+* discussion of transaction research and implementations on Slack,
+* help understanding and configuring transactions in TiKV and TiDB,
+* support for contributors to TiKV and related projects.
+
+See our [repository](https://github.com/tikv/sig-transaction) for more information.
+
+## How to get involved
+
+You can join us in #sig-transaction in the [TiKV community Slack](https://slack.tidb.io/invite?team=tikv-wg&channel=sig-transaction&ref=community-sig); come say hi! We use English and Chinese.
+
+You can read or join our announcement [mailing list](https://groups.google.com/d/forum/tikv-sig-transaction), so you can stay up to date with what we're up to.
+
+We will have formal membership of the group ready later in the year.


### PR DESCRIPTION
This PR adds a small community page (fixing a broken link from the community menu in the process - closes #171). From there, there is a link to a basic page for each SIG. We will use the transaction sig page as a landing page for attracting new members.

PTAL @dcalvin 