### PR TITLE
fix(percolator): right anchor

### DIFF
--- a/content/deep-dive/distributed-transaction/percolator.md
+++ b/content/deep-dive/distributed-transaction/percolator.md
@@ -11,7 +11,7 @@ TiKV supports distributed transactions, which is inspired by Google's [Percolato
 
 ## What is Percolator?
 
-*Percolator* is a system built by Google for incremental processing on a very large data set. Since this is just a brief introduction, you can view the full paper [here](https://ai.google/research/pubs/pub36726#) for more details. If you are already very familiar with it, you can skip this section and go directly to [Percolator in TiKV](#Percolator-in-TiKV)
+*Percolator* is a system built by Google for incremental processing on a very large data set. Since this is just a brief introduction, you can view the full paper [here](https://ai.google/research/pubs/pub36726#) for more details. If you are already very familiar with it, you can skip this section and go directly to [Percolator in TiKV](#percolator-in-tikv)
 
 Percolator is built based on Google's BigTable, a distributed storage system that supports single-row transactions. Percolator implements distributed transactions in ACID snapshot-isolation semantics, which is not supported by BigTable. A column `c` of Percolator is actually divided into the following internal columns of BigTable:
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiKV documentation. -->

### What is changed?

Fixed a small typo in a local anchor.

### Any related PRs or issues?

None

### Which version does your change affect?

The faulty anchor can be viewed on [https://tikv.org/deep-dive/distributed-transaction/percolator/](https://tikv.org/deep-dive/distributed-transaction/percolator/). When clicking on [Percolator in TiKV](https://tikv.org/deep-dive/distributed-transaction/percolator/#Percolator-in-TiKV), nothing is happening.


Extract of the generated HTML for the link:

```html
can skip this section and go directly to <a href=#Percolator-in-TiKV>Percolator in TiKV</a>
```

Extract of the generated HTML for the anchor:
```html
<h2 id=percolator-in-tikv>Percolator in TiKV</h2>
```