### PR TITLE
enable goldmark `unsafe` renderer option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -73,3 +73,8 @@ mediaTypes:
         delimiter: ""
 
 enableGitInfo: true
+
+markup:
+    goldmark:
+        renderer:
+            unsafe: true


### PR DESCRIPTION
`unsafe` is needed to render table with multilines cell properly,
for example in deep-dive/distributed-transaction/percolator/,
refer to https://gohugo.io/getting-started/configuration-markup/
for more information.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>

<!--Thanks for your contribution to TiKV documentation. -->

### What is changed?

<!--Tell us what you did and why.-->

### Any related PRs or issues?

<!--Provide a reference link that is related to your change. -->

### Which version does your change affect?
