### PR TITLE
Fix main.rs in the docker stack example

### DIFF
--- a/content/docs/3.0/tasks/try/docker-stack.md
+++ b/content/docs/3.0/tasks/try/docker-stack.md
@@ -260,7 +260,7 @@ Next, you'll need to add the TiKV client as a dependency in the `Cargo.toml` fil
 ```toml
 [dependencies]
 tikv-client = { git = "https://github.com/tikv/client-rust.git" }
-tokio = "0.2.0-alpha.4"
+tokio = "1"
 ```
 
 Then you can edit the `src/main.rs` file with the following:
@@ -270,8 +270,7 @@ use tikv_client::{Config, RawClient, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let config = Config::new(vec!["http://pd.tikv:2379"]);
-    let client = RawClient::new(config)?;
+    let client = RawClient::new(vec!["127.0.0.1:2379"], None).await?;
     let key = "TiKV".as_bytes().to_owned();
     let value = "Works!".as_bytes().to_owned();
 

--- a/content/docs/4.0/tasks/try/docker-stack.md
+++ b/content/docs/4.0/tasks/try/docker-stack.md
@@ -271,7 +271,7 @@ use tikv_client::{Config, RawClient, Error};
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     let config = Config::new(vec!["http://pd.tikv:2379"]);
-    let client = RawClient::new(config)?;
+    let client = RawClient::new(config).await?;
     let key = "TiKV".as_bytes().to_owned();
     let value = "Works!".as_bytes().to_owned();
 

--- a/content/docs/4.0/tasks/try/docker-stack.md
+++ b/content/docs/4.0/tasks/try/docker-stack.md
@@ -260,7 +260,7 @@ Next, you'll need to add the TiKV client as a dependency in the `Cargo.toml` fil
 ```toml
 [dependencies]
 tikv-client = { git = "https://github.com/tikv/client-rust.git" }
-tokio = "0.2.0-alpha.4"
+tokio = "1"
 ```
 
 Then you can edit the `src/main.rs` file with the following:
@@ -270,8 +270,7 @@ use tikv_client::{Config, RawClient, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let config = Config::new(vec!["http://pd.tikv:2379"]);
-    let client = RawClient::new(config).await?;
+    let client = RawClient::new(vec!["127.0.0.1:2379"], None).await?;
     let key = "TiKV".as_bytes().to_owned();
     let value = "Works!".as_bytes().to_owned();
 

--- a/content/docs/dev/tasks/try/docker-stack.md
+++ b/content/docs/dev/tasks/try/docker-stack.md
@@ -260,7 +260,7 @@ Next, you'll need to add the TiKV client as a dependency in the `Cargo.toml` fil
 ```toml
 [dependencies]
 tikv-client = { git = "https://github.com/tikv/client-rust.git" }
-tokio = "0.2.0-alpha.4"
+tokio = "1"
 ```
 
 Then you can edit the `src/main.rs` file with the following:
@@ -270,10 +270,7 @@ use tikv_client::{Config, RawClient, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let config = Config::new(vec!["http://pd.tikv:2379"]);
-    let client = RawClient::new(config)?;
-    let key = "TiKV".as_bytes().to_owned();
-    let value = "Works!".as_bytes().to_owned();
+    let client = RawClient::new(vec!["127.0.0.1:2379"], None).await?;
 
     client.put(key.clone(), value.clone()).await?;
     println!(

--- a/content/docs/dev/tasks/try/docker-stack.md
+++ b/content/docs/dev/tasks/try/docker-stack.md
@@ -272,6 +272,9 @@ use tikv_client::{Config, RawClient, Error};
 async fn main() -> Result<(), Error> {
     let client = RawClient::new(vec!["127.0.0.1:2379"], None).await?;
 
+    let key = "TiKV".as_bytes().to_owned();
+    let value = "Works!".as_bytes().to_owned();
+
     client.put(key.clone(), value.clone()).await?;
     println!(
         "Put: {} => {}",


### PR DESCRIPTION
The `src/main.rs` in https://tikv.org/docs/4.0/tasks/try/docker-stack/ does not compile. It fails with:

```
the `?` operator cannot be applied to type `impl std::future::Future`
help: consider using `.await` here: `RawClient::new(config).await?`
```

Adding `await` as the compiler suggests fixes the issue.
