### PR TITLE
Remove duplicate command in create namespace section of operator doc

### DIFF
--- a/content/docs/4.0/tasks/try/tikv-operator.md
+++ b/content/docs/4.0/tasks/try/tikv-operator.md
@@ -81,7 +81,6 @@ Before deployment, make sure the following requirements are satisfied:
 
     ```shell
     kubectl create ns tikv-operator
-    helm install --namespace tikv-operator tikv-operator pingcap/tikv-operator --version v0.1.0
     ```
 
     c. Install TiKV Operator:


### PR DESCRIPTION
<!--Thanks for your contribution to TiKV documentation. -->

### What is changed?

`helm install --namespace tikv-operator tikv-operator pingcap/tikv-operator --version v0.1.0` is for creating operator, not creating namespace. I remove it from create namespace section.

### Any related PRs or issues?

IDK

### Which version does your change affect?

4.0
