### PR TITLE
use v5.1 as default document

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ params:
     favicon: "favicon.png"
     googleAnalyticsId: "UA-130734531-1"
     versions:
-        latest: "4.0"
+        latest: "5.1"
         all:
         - "dev"
         - "5.1"


### PR DESCRIPTION
<!--Thanks for your contribution to TiKV documentation. -->

### What is changed?


TiKV's official website is planned to be refactored as discussed in https://github.com/tikv/website/issues/227.

Use v5.1 as default document.

<!--Tell us what you did and why.-->

### Any related PRs or issues?

<!--Provide a reference link that is related to your change. -->

https://github.com/tikv/website/issues/227

### Which version does your change affect?
