### PR TITLE
docs: fix dead link and info macro format in benchmark

### DIFF
--- a/content/docs/5.1/deploy/performance/instructions.md
+++ b/content/docs/5.1/deploy/performance/instructions.md
@@ -23,7 +23,7 @@ TiKV delivers predictable throughput and latency at all scales on commodity hard
     | TiKV          | 8 cores or above | 32 GB or above | SSD, 200 GB or above | Gigabit LAN | 3                               |
 
     {{< info >}}
-    It is recommended to use local SSDs as the store volume for the instances. Local SSDs are low-latency disks attached to each node and can maximize performance. It is not recommended to use the network-attached block storage. It is recommended to deploy TiKV on NVMe SSDs to maximize its capacity.
+It is recommended to use local SSDs as the store volume for the instances. Local SSDs are low-latency disks attached to each node and can maximize performance. It is not recommended to use the network-attached block storage. It is recommended to deploy TiKV on NVMe SSDs to maximize its capacity.
     {{< /info >}}
 
 2. Prepare services for the control node and component nodes.
@@ -50,7 +50,7 @@ TiKV delivers predictable throughput and latency at all scales on commodity hard
     | [go-ycsb](https://github.com/pingcap/go-ycsb) | No requirement | For benchmark |
 
     {{< info >}}
-    You can install [TiUP](https://github.com/pingcap/tiup) as described in [TiKV in 5 Minutes](../../tikv-in-5-minutes).
+You can install [TiUP](https://github.com/pingcap/tiup) as described in [TiKV in 5 Minutes](../../tikv-in-5-minutes).
     {{< /info >}}
 
 ## Step 2. Deploy a TiKV cluster

--- a/content/docs/5.1/deploy/performance/overview.md
+++ b/content/docs/5.1/deploy/performance/overview.md
@@ -10,7 +10,7 @@ menu:
  
 TiKV can deliver predictable throughput and latency at all scales on requiring hardware. This document provides an overview of TiKV benchmark performance on throughput and latency.
 
-To learn how to reproduce the benchmark results in this document, see [Benchmark Instructions](./instructions.md). If you do not achieve similar results, check whether your hardware, workload, and test design meet the requirements in this document.
+To learn how to reproduce the benchmark results in this document, see [Benchmark Instructions](../instructions). If you do not achieve similar results, check whether your hardware, workload, and test design meet the requirements in this document.
 
 ## Baseline
 


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>
