### PR TITLE
fix: transaction-overview not found for version 5.1

### DIFF
--- a/content/docs/5.1/reference/architecture/storage.md
+++ b/content/docs/5.1/reference/architecture/storage.md
@@ -111,4 +111,4 @@ Note that for multiple versions of the same Key, versions with larger numbers ar
 
 ## Distributed ACID transaction
 
-Transaction of TiKV adopts the model used by Google in BigTable: [Percolator](https://research.google.com/pubs/pub36726.html). TiKV's implementation is inspired by this paper, with a lot of optimizations. See [transaction overview](/transaction-overview.md) for details.
+Transaction of TiKV adopts the model used by Google in BigTable: [Percolator](https://research.google.com/pubs/pub36726.html). TiKV's implementation is inspired by this paper, with a lot of optimizations. See [transaction overview](/deep-dive/distributed-transaction/introduction) for details.


### PR DESCRIPTION
<!--Thanks for your contribution to TiKV documentation. -->

### What is changed?
![image](https://user-images.githubusercontent.com/18672896/176813154-7e2cefee-3fce-4966-8a8b-94953fa2bf53.png)
link not found
<!--Tell us what you did and why.-->

### Any related PRs or issues?
No
<!--Provide a reference link that is related to your change. -->

### Which version does your change affect?
Updated, click refreshto https://tikv.org/deep-dive/distributed-transaction/introduction/
