### PR TITLE
Strip HTML from <title> attribute; fixes the <br /> that is currently showing up there

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,7 +11,7 @@
   {{ partial "meta.html" . }}
   {{ partial "twitter-card.html" . }}
   {{ partial "open-graph-tags.html" . }}
-  <title>{{ block "title" . }}{{ site.Title }} | {{ site.Params.description.brief }}{{ end }}</title>
+  <title>{{ block "title" . }}{{ site.Title }} | {{ site.Params.description.brief | plainify }}{{ end }}</title>
   {{ partial "css.html" . }}
 </head>
 


### PR DESCRIPTION
### What is changed?
Currently, the web site at [tikv.org](https://tikv.org) has a literal `<br />` in the `<title>` tag:

<img width="536" alt="Screenshot 2023-02-01 at 9 38 22 AM" src="https://user-images.githubusercontent.com/41654/216120134-49bb464c-9ba6-4fa8-9ca6-13bb9b2ab704.png">

This changes the template to run the description through [Hugo's plainify function](https://gohugo.io/functions/plainify/), which strips out all HTML tags and returns a plain text version of the input.

Tada:
<img width="513" alt="Screenshot 2023-02-01 at 9 39 59 AM" src="https://user-images.githubusercontent.com/41654/216120562-f1da90ea-7868-42be-999f-b63f86b50299.png">


### Any related PRs or issues?

N/A

### Which version does your change affect?

N/A