### PR TITLE
client java/rust/go should support TLS

### DIFF
--- a/content/docs/7.1/deploy/configure/security.md
+++ b/content/docs/7.1/deploy/configure/security.md
@@ -124,7 +124,11 @@ For the information about all TLS configuration parameters of PD, see [PD securi
 
 ## Step 3. Configure the TiKV client
 
-You need to set TLS options for the TiKV client to connect to TiKV. Taking [Rust Client](https://github.com/tikv/client-rust) as an example, the TLS options are set as follows:
+You need to set TLS options for the TiKV client to connect to TiKV. 
+
+### [Rust Client](https://github.com/tikv/client-rust)
+
+the TLS options are set as follows:
 
 ```rust
 let config = Config::new(/* ... */).with_security(
@@ -137,11 +141,13 @@ let config = Config::new(/* ... */).with_security(
 );
 ```
 
-Besides, the **connection URL should be changed to `https://`** instead of a plain `ip:port`.
+### [Java Client](https://github.com/tikv/client-java)
 
-{{< warning >}}
-Currently, TiKV Java Client does not support TLS.
-{{< /warning >}}
+Check the [Java client documentation](https://tikv.github.io/client-java/administration/configuration.html#tikvtls_enable)
+
+### [Go Client](https://github.com/tikv/client-go)
+
+Check the [Go client documentation](https://pkg.go.dev/github.com/tikv/client-go/v2@v2.0.7/config#Security)
 
 ## Step 4. Connect TiKV using `tikv-ctl` and `pd-ctl`
 

--- a/content/docs/7.1/deploy/configure/security.md
+++ b/content/docs/7.1/deploy/configure/security.md
@@ -128,8 +128,6 @@ You need to set TLS options for the TiKV client to connect to TiKV.
 
 ### [Rust Client](https://github.com/tikv/client-rust)
 
-the TLS options are set as follows:
-
 ```rust
 let config = Config::new(/* ... */).with_security(
     // The path to the file that contains the PEM encoding of the server’s CA certificates.
@@ -143,11 +141,30 @@ let config = Config::new(/* ... */).with_security(
 
 ### [Java Client](https://github.com/tikv/client-java)
 
-Check the [Java client documentation](https://tikv.github.io/client-java/administration/configuration.html#tikvtls_enable)
+```java
+TiConfiguration conf = TiConfiguration.createRawDefault("127.0.0.1:2379");
+conf.setTlsEnable(true);
+conf.setTrustCertCollectionFile("/path/to/ca.pem");
+conf.setKeyCertChainFile("/path/to/cert.pem");
+conf.setKeyFile("/path/to/key.pem");
+```
+
+For more information about the TLS config of Java client, check the [Java client documentation](https://tikv.github.io/client-java/administration/configuration.html#tikvtls_enable)
 
 ### [Go Client](https://github.com/tikv/client-go)
 
-Check the [Go client documentation](https://pkg.go.dev/github.com/tikv/client-go/v2@v2.0.7/config#Security)
+```go
+cli, err := rawkv.NewClient(context.TODO(), []string{"127.0.0.1:2379"}, config.Security{
+    ClusterSSLCA:    "/path/to/ca.pem",
+    ClusterSSLCert:  "/path/to/cert.pem",
+    ClusterSSLKey:   "/path/to/key.pem",
+})
+if err != nil {
+    panic(err)
+}
+```
+
+For more information about the TLS config of Go client, check the [Go client documentation](https://pkg.go.dev/github.com/tikv/client-go/v2@v2.0.7/config#Security)
 
 ## Step 4. Connect TiKV using `tikv-ctl` and `pd-ctl`
 

--- a/content/docs/dev/deploy/configure/security.md
+++ b/content/docs/dev/deploy/configure/security.md
@@ -124,7 +124,11 @@ For the information about all TLS configuration parameters of PD, see [PD securi
 
 ## Step 3. Configure the TiKV client
 
-You need to set TLS options for the TiKV client to connect to TiKV. Taking [Rust Client](https://github.com/tikv/client-rust) as an example, the TLS options are set as follows:
+You need to set TLS options for the TiKV client to connect to TiKV. 
+
+### [Rust Client](https://github.com/tikv/client-rust)
+
+the TLS options are set as follows:
 
 ```rust
 let config = Config::new(/* ... */).with_security(
@@ -137,11 +141,13 @@ let config = Config::new(/* ... */).with_security(
 );
 ```
 
-Besides, the **connection URL should be changed to `https://`** instead of a plain `ip:port`.
+### [Java Client](https://github.com/tikv/client-java)
 
-{{< warning >}}
-Currently, TiKV Java Client does not support TLS.
-{{< /warning >}}
+Check the [Java client documentation](https://tikv.github.io/client-java/administration/configuration.html#tikvtls_enable)
+
+### [Go Client](https://github.com/tikv/client-go)
+
+Check the [Go client documentation](https://pkg.go.dev/github.com/tikv/client-go/v2@v2.0.7/config#Security)
 
 ## Step 4. Connect TiKV using `tikv-ctl` and `pd-ctl`
 

--- a/content/docs/dev/deploy/configure/security.md
+++ b/content/docs/dev/deploy/configure/security.md
@@ -128,8 +128,6 @@ You need to set TLS options for the TiKV client to connect to TiKV.
 
 ### [Rust Client](https://github.com/tikv/client-rust)
 
-the TLS options are set as follows:
-
 ```rust
 let config = Config::new(/* ... */).with_security(
     // The path to the file that contains the PEM encoding of the server’s CA certificates.
@@ -143,11 +141,30 @@ let config = Config::new(/* ... */).with_security(
 
 ### [Java Client](https://github.com/tikv/client-java)
 
-Check the [Java client documentation](https://tikv.github.io/client-java/administration/configuration.html#tikvtls_enable)
+```java
+TiConfiguration conf = TiConfiguration.createRawDefault("127.0.0.1:2379");
+conf.setTlsEnable(true);
+conf.setTrustCertCollectionFile("/path/to/ca.pem");
+conf.setKeyCertChainFile("/path/to/cert.pem");
+conf.setKeyFile("/path/to/key.pem");
+```
+
+For more information about the TLS config of Java client, check the [Java client documentation](https://tikv.github.io/client-java/administration/configuration.html#tikvtls_enable)
 
 ### [Go Client](https://github.com/tikv/client-go)
 
-Check the [Go client documentation](https://pkg.go.dev/github.com/tikv/client-go/v2@v2.0.7/config#Security)
+```go
+cli, err := rawkv.NewClient(context.TODO(), []string{"127.0.0.1:2379"}, config.Security{
+    ClusterSSLCA:    "/path/to/ca.pem",
+    ClusterSSLCert:  "/path/to/cert.pem",
+    ClusterSSLKey:   "/path/to/key.pem",
+})
+if err != nil {
+    panic(err)
+}
+```
+
+For more information about the TLS config of Go client, check the [Go client documentation](https://pkg.go.dev/github.com/tikv/client-go/v2@v2.0.7/config#Security)
 
 ## Step 4. Connect TiKV using `tikv-ctl` and `pd-ctl`
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiKV documentation. -->

### What has changed?

Update the TLS config docs for TiKV Clients, including rust/go/java, they all support TLS now. 

<!--Tell us what you did and why.-->

### Any related PRs or issues?

<!--Provide a reference link that is related to your change. -->

### Which version does your change affect?
dev, 7.1
