### PR TITLE
Fix labels config syntax

### DIFF
--- a/content/docs/6.1/deploy/configure/topology.md
+++ b/content/docs/6.1/deploy/configure/topology.md
@@ -45,7 +45,7 @@ Assume that the topology has three layers: `zone > rack > host`. You can set a l
 
     ```toml
     [server]
-    labels = "zone=<zone>,rack=<rack>,host=<host>"
+    labels = {zone="<zone>",rack="<rack>",host="<host>"}
     ```
 
 ## Example

--- a/content/docs/6.5/deploy/configure/topology.md
+++ b/content/docs/6.5/deploy/configure/topology.md
@@ -45,7 +45,7 @@ Assume that the topology has three layers: `zone > rack > host`. You can set a l
 
     ```toml
     [server]
-    labels = "zone=<zone>,rack=<rack>,host=<host>"
+    labels = {zone="<zone>",rack="<rack>",host="<host>"}
     ```
 
 ## Example

--- a/content/docs/7.1/deploy/configure/topology.md
+++ b/content/docs/7.1/deploy/configure/topology.md
@@ -45,7 +45,7 @@ Assume that the topology has three layers: `zone > rack > host`. You can set a l
 
     ```toml
     [server]
-    labels = "zone=<zone>,rack=<rack>,host=<host>"
+    labels = {zone="<zone>",rack="<rack>",host="<host>"}
     ```
 
 ## Example

--- a/content/docs/dev/deploy/configure/topology.md
+++ b/content/docs/dev/deploy/configure/topology.md
@@ -45,7 +45,7 @@ Assume that the topology has three layers: `zone > rack > host`. You can set a l
 
     ```toml
     [server]
-    labels = "zone=<zone>,rack=<rack>,host=<host>"
+    labels = {zone="<zone>",rack="<rack>",host="<host>"}
     ```
 
 ## Example


### PR DESCRIPTION
<!--Thanks for your contribution to TiKV documentation. -->

### What is changed?

The labels are not a string.

```
invalid auto generated configuration file /home/dvaneeden/.tiup/data/UaWnp6Q/tikv-0/tikv.toml, err invalid type: string "foo=bar", expected a map for key `server.labels` at line 8 column 10
```

Alternative syntax from https://docs.pingcap.com/tidb/stable/schedule-replicas-by-topology-labels#configure-labels-for-tikv-and-tiflash

```
[server.labels]
zone = "<zone>"
dc = "<dc>"
rack = "<rack>"
host = "<host>"
```

This doesn't work:
```
tiup playground --kv.config <(echo -en "[server]\nlabels = \"foo=bar\"\n") v8.5.0
```

This does:
```
tiup playground --kv.config <(echo -en "[server]\nlabels = {foo=\"bar\"}\n") v8.5.0
```

### Any related PRs or issues?

<!--Provide a reference link that is related to your change. -->

### Which version does your change affect?
