### PR TITLE
docs: replace deprecated PingCAP domains

### DIFF
--- a/content/docs/3.0/tasks/deploy/binary.md
+++ b/content/docs/3.0/tasks/deploy/binary.md
@@ -27,8 +27,8 @@ This section describes how to deploy TiKV on a single machine installed with the
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256
@@ -97,8 +97,8 @@ To deploy a TiKV cluster with multiple nodes for test, take the following steps:
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256

--- a/content/docs/3.0/tasks/try/tikv-operator.md
+++ b/content/docs/3.0/tasks/try/tikv-operator.md
@@ -72,7 +72,7 @@ Before deployment, make sure the following requirements are satisfied:
     1. Add the PingCAP Repository:
 
         ```shell
-        helm repo add pingcap https://charts.pingcap.org/
+        helm repo add pingcap https://charts.pingcap.com/
         ```
 
     2. Create a namespace for TiKV Operator:

--- a/content/docs/4.0/tasks/deploy/binary.md
+++ b/content/docs/4.0/tasks/deploy/binary.md
@@ -27,8 +27,8 @@ This section describes how to deploy TiKV on a single machine installed with the
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256
@@ -97,8 +97,8 @@ To deploy a TiKV cluster with multiple nodes for test, take the following steps:
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256

--- a/content/docs/4.0/tasks/try/tikv-operator.md
+++ b/content/docs/4.0/tasks/try/tikv-operator.md
@@ -74,7 +74,7 @@ Before deployment, make sure the following requirements are satisfied:
     a. Add the PingCAP Repository:
 
     ```shell
-    helm repo add pingcap https://charts.pingcap.org/
+    helm repo add pingcap https://charts.pingcap.com/
     ```
 
     b. Create a namespace for TiKV Operator:

--- a/content/docs/5.1/deploy/install/test.md
+++ b/content/docs/5.1/deploy/install/test.md
@@ -85,8 +85,8 @@ This section describes how to deploy TiKV on a single machine installed with the
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256
@@ -155,8 +155,8 @@ To deploy a TiKV cluster with multiple nodes for test, take the following steps:
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256

--- a/content/docs/5.1/deploy/install/verify.md
+++ b/content/docs/5.1/deploy/install/verify.md
@@ -36,7 +36,7 @@ This section describes how to connect to the TiKV cluster using a TiKV client to
 1. Download jars
 
     ```bash
-    curl -o tikv-client-java.jar https://download.pingcap.org/tikv-client-java-3.1.0-SNAPSHOT.jar
+    curl -o tikv-client-java.jar https://download.pingcap.com/tikv-client-java-3.1.0-SNAPSHOT.jar
     curl -o slf4j-api.jar https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.16/slf4j-api-1.7.16.jar
     ```
 

--- a/content/docs/5.1/deploy/monitor/deploy.md
+++ b/content/docs/5.1/deploy/monitor/deploy.md
@@ -28,9 +28,9 @@ Assume that the TiKV cluster topology is as follows:
 
 ```bash
 # Downloads the package.
-wget https://download.pingcap.org/prometheus-2.8.1.linux-amd64.tar.gz
-wget https://download.pingcap.org/node_exporter-0.17.0.linux-amd64.tar.gz
-wget https://download.pingcap.org/grafana-6.1.6.linux-amd64.tar.gz
+wget https://download.pingcap.com/prometheus-2.8.1.linux-amd64.tar.gz
+wget https://download.pingcap.com/node_exporter-0.17.0.linux-amd64.tar.gz
+wget https://download.pingcap.com/grafana-6.1.6.linux-amd64.tar.gz
 ```
 
 ```bash

--- a/content/docs/5.1/reference/CLI/pd-ctl.md
+++ b/content/docs/5.1/reference/CLI/pd-ctl.md
@@ -25,10 +25,10 @@ Download the following installation package where PD Control binary locates.
 
 | Package download link                                            | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ### Compile from source code

--- a/content/docs/5.1/reference/CLI/pd-recover.md
+++ b/content/docs/5.1/reference/CLI/pd-recover.md
@@ -27,10 +27,10 @@ Download the following installation package where PD Recover binary locates.
 
 | Package name                                                     | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ## Quick Start

--- a/content/docs/6.1/deploy/install/test.md
+++ b/content/docs/6.1/deploy/install/test.md
@@ -86,8 +86,8 @@ This section describes how to deploy TiKV on a single machine (Linux for example
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256
@@ -156,8 +156,8 @@ To deploy a TiKV cluster with multiple nodes for test, take the following steps:
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256

--- a/content/docs/6.1/deploy/install/verify.md
+++ b/content/docs/6.1/deploy/install/verify.md
@@ -37,7 +37,7 @@ This section describes how to connect to the TiKV cluster using a TiKV client to
 1. Download jars
 
     ```bash
-    curl -o tikv-client-java.jar https://download.pingcap.org/tikv-client-java-3.1.0-SNAPSHOT.jar
+    curl -o tikv-client-java.jar https://download.pingcap.com/tikv-client-java-3.1.0-SNAPSHOT.jar
     curl -o slf4j-api.jar https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.16/slf4j-api-1.7.16.jar
     ```
 

--- a/content/docs/6.1/deploy/monitor/deploy.md
+++ b/content/docs/6.1/deploy/monitor/deploy.md
@@ -29,9 +29,9 @@ Assume that the TiKV cluster topology is as follows:
 
 ```bash
 # Downloads the package.
-wget https://download.pingcap.org/prometheus-2.8.1.linux-amd64.tar.gz
-wget https://download.pingcap.org/node_exporter-0.17.0.linux-amd64.tar.gz
-wget https://download.pingcap.org/grafana-6.1.6.linux-amd64.tar.gz
+wget https://download.pingcap.com/prometheus-2.8.1.linux-amd64.tar.gz
+wget https://download.pingcap.com/node_exporter-0.17.0.linux-amd64.tar.gz
+wget https://download.pingcap.com/grafana-6.1.6.linux-amd64.tar.gz
 ```
 
 ```bash

--- a/content/docs/6.1/reference/CLI/pd-ctl.md
+++ b/content/docs/6.1/reference/CLI/pd-ctl.md
@@ -26,10 +26,10 @@ Download the following installation package where PD Control binary locates.
 
 | Package download link                                            | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ### Compile from source code

--- a/content/docs/6.1/reference/CLI/pd-recover.md
+++ b/content/docs/6.1/reference/CLI/pd-recover.md
@@ -28,10 +28,10 @@ Download the following installation package where PD Recover binary locates.
 
 | Package name                                                     | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ## Quick Start

--- a/content/docs/6.5/deploy/install/test.md
+++ b/content/docs/6.5/deploy/install/test.md
@@ -86,8 +86,8 @@ This section describes how to deploy TiKV on a single machine (Linux for example
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256
@@ -156,8 +156,8 @@ To deploy a TiKV cluster with multiple nodes for test, take the following steps:
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256

--- a/content/docs/6.5/deploy/install/verify.md
+++ b/content/docs/6.5/deploy/install/verify.md
@@ -37,7 +37,7 @@ This section describes how to connect to the TiKV cluster using a TiKV client to
 1. Download jars
 
     ```bash
-    curl -o tikv-client-java.jar https://download.pingcap.org/tikv-client-java-3.1.0-SNAPSHOT.jar
+    curl -o tikv-client-java.jar https://download.pingcap.com/tikv-client-java-3.1.0-SNAPSHOT.jar
     curl -o slf4j-api.jar https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.16/slf4j-api-1.7.16.jar
     ```
 

--- a/content/docs/6.5/deploy/monitor/deploy.md
+++ b/content/docs/6.5/deploy/monitor/deploy.md
@@ -29,9 +29,9 @@ Assume that the TiKV cluster topology is as follows:
 
 ```bash
 # Downloads the package.
-wget https://download.pingcap.org/prometheus-2.8.1.linux-amd64.tar.gz
-wget https://download.pingcap.org/node_exporter-0.17.0.linux-amd64.tar.gz
-wget https://download.pingcap.org/grafana-6.1.6.linux-amd64.tar.gz
+wget https://download.pingcap.com/prometheus-2.8.1.linux-amd64.tar.gz
+wget https://download.pingcap.com/node_exporter-0.17.0.linux-amd64.tar.gz
+wget https://download.pingcap.com/grafana-6.1.6.linux-amd64.tar.gz
 ```
 
 ```bash

--- a/content/docs/6.5/reference/CLI/pd-ctl.md
+++ b/content/docs/6.5/reference/CLI/pd-ctl.md
@@ -26,10 +26,10 @@ Download the following installation package where PD Control binary locates.
 
 | Package download link                                            | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ### Compile from source code

--- a/content/docs/6.5/reference/CLI/pd-recover.md
+++ b/content/docs/6.5/reference/CLI/pd-recover.md
@@ -28,10 +28,10 @@ Download the following installation package where PD Recover binary locates.
 
 | Package name                                                     | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ## Quick Start

--- a/content/docs/7.1/deploy/install/test.md
+++ b/content/docs/7.1/deploy/install/test.md
@@ -86,8 +86,8 @@ This section describes how to deploy TiKV on a single machine (Linux for example
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256
@@ -156,8 +156,8 @@ To deploy a TiKV cluster with multiple nodes for test, take the following steps:
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256

--- a/content/docs/7.1/deploy/install/verify.md
+++ b/content/docs/7.1/deploy/install/verify.md
@@ -37,7 +37,7 @@ This section describes how to connect to the TiKV cluster using a TiKV client to
 1. Download jars
 
     ```bash
-    curl -o tikv-client-java.jar https://download.pingcap.org/tikv-client-java-3.1.0-SNAPSHOT.jar
+    curl -o tikv-client-java.jar https://download.pingcap.com/tikv-client-java-3.1.0-SNAPSHOT.jar
     curl -o slf4j-api.jar https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.16/slf4j-api-1.7.16.jar
     ```
 

--- a/content/docs/7.1/deploy/monitor/deploy.md
+++ b/content/docs/7.1/deploy/monitor/deploy.md
@@ -29,9 +29,9 @@ Assume that the TiKV cluster topology is as follows:
 
 ```bash
 # Downloads the package.
-wget https://download.pingcap.org/prometheus-2.8.1.linux-amd64.tar.gz
-wget https://download.pingcap.org/node_exporter-0.17.0.linux-amd64.tar.gz
-wget https://download.pingcap.org/grafana-6.1.6.linux-amd64.tar.gz
+wget https://download.pingcap.com/prometheus-2.8.1.linux-amd64.tar.gz
+wget https://download.pingcap.com/node_exporter-0.17.0.linux-amd64.tar.gz
+wget https://download.pingcap.com/grafana-6.1.6.linux-amd64.tar.gz
 ```
 
 ```bash

--- a/content/docs/7.1/reference/CLI/pd-ctl.md
+++ b/content/docs/7.1/reference/CLI/pd-ctl.md
@@ -26,10 +26,10 @@ Download the following installation package where PD Control binary locates.
 
 | Package download link                                            | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ### Compile from source code

--- a/content/docs/7.1/reference/CLI/pd-recover.md
+++ b/content/docs/7.1/reference/CLI/pd-recover.md
@@ -28,10 +28,10 @@ Download the following installation package where PD Recover binary locates.
 
 | Package name                                                     | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ## Quick Start

--- a/content/docs/dev/deploy/install/test.md
+++ b/content/docs/dev/deploy/install/test.md
@@ -86,8 +86,8 @@ This section describes how to deploy TiKV on a single machine (Linux for example
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256
@@ -156,8 +156,8 @@ To deploy a TiKV cluster with multiple nodes for test, take the following steps:
 
     ```bash
     # Download the package.
-    wget https://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
-    wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+    wget https://download.pingcap.com/tidb-latest-linux-amd64.tar.gz
+    wget http://download.pingcap.com/tidb-latest-linux-amd64.sha256
 
     # Check the file integrity. If the result is OK, the file is correct.
     sha256sum -c tidb-latest-linux-amd64.sha256

--- a/content/docs/dev/deploy/install/verify.md
+++ b/content/docs/dev/deploy/install/verify.md
@@ -37,7 +37,7 @@ This section describes how to connect to the TiKV cluster using a TiKV client to
 1. Download jars
 
     ```bash
-    curl -o tikv-client-java.jar https://download.pingcap.org/tikv-client-java-3.1.0-SNAPSHOT.jar
+    curl -o tikv-client-java.jar https://download.pingcap.com/tikv-client-java-3.1.0-SNAPSHOT.jar
     curl -o slf4j-api.jar https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.16/slf4j-api-1.7.16.jar
     ```
 

--- a/content/docs/dev/deploy/monitor/deploy.md
+++ b/content/docs/dev/deploy/monitor/deploy.md
@@ -29,9 +29,9 @@ Assume that the TiKV cluster topology is as follows:
 
 ```bash
 # Downloads the package.
-wget https://download.pingcap.org/prometheus-2.8.1.linux-amd64.tar.gz
-wget https://download.pingcap.org/node_exporter-0.17.0.linux-amd64.tar.gz
-wget https://download.pingcap.org/grafana-6.1.6.linux-amd64.tar.gz
+wget https://download.pingcap.com/prometheus-2.8.1.linux-amd64.tar.gz
+wget https://download.pingcap.com/node_exporter-0.17.0.linux-amd64.tar.gz
+wget https://download.pingcap.com/grafana-6.1.6.linux-amd64.tar.gz
 ```
 
 ```bash

--- a/content/docs/dev/reference/CLI/pd-ctl.md
+++ b/content/docs/dev/reference/CLI/pd-ctl.md
@@ -26,10 +26,10 @@ Download the following installation package where PD Control binary locates.
 
 | Package download link                                            | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ### Compile from source code

--- a/content/docs/dev/reference/CLI/pd-recover.md
+++ b/content/docs/dev/reference/CLI/pd-recover.md
@@ -28,10 +28,10 @@ Download the following installation package where PD Recover binary locates.
 
 | Package name                                                     | OS    | Architecture | SHA256 checksum                                                  |
 |:---------------------------------------------------------------- |:----- |:------------ |:---------------------------------------------------------------- |
-| `https://download.pingcap.org/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.org/tidb-{version}-linux-amd64.sha256` |
+| `https://download.pingcap.com/tidb-{version}-linux-amd64.tar.gz` | Linux | amd64        | `https://download.pingcap.com/tidb-{version}-linux-amd64.sha256` |
 
 {{< info >}}
-`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.org/tidb-v5.0.0-linux-amd64.tar.gz`.
+`{version}` indicates the version number of TiKV. For example, if `{version}` is `v5.0.0`, the package download link is `https://download.pingcap.com/tidb-v5.0.0-linux-amd64.tar.gz`.
 {{< /info >}}
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- replace deprecated `download.pingcap.org` references with `download.pingcap.com`
- replace deprecated `charts.pingcap.org` references with `charts.pingcap.com`
- keep existing paths and protocols unchanged

## Validation
- `git diff --check`
- verified no remaining `download.pingcap.org` / `charts.pingcap.org` references in the patched branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated download URLs across installation, deployment, testing, verification, and monitoring guides to use the new download.pingcap.com domain for TiDB, TiKV, Prometheus, node_exporter, Grafana, and Java client artifacts.
  * Updated Helm chart repository URLs for TiKV Operator setup to use https://charts.pingcap.com/ across documentation versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->